### PR TITLE
Fix config reader return logic

### DIFF
--- a/services/scan-directories/src/config-reader.ts
+++ b/services/scan-directories/src/config-reader.ts
@@ -66,5 +66,5 @@ export function getDataPath(
   const config = getConfig(configPath);
   const folderPath = getFolderPath(pathAlias, config, rootPath);
   console.log(`folderPath: ${folderPath}`);
-  return getFolderPath(pathAlias, config, rootPath) || '';
+  return folderPath || '';
 }


### PR DESCRIPTION
## Summary
- update `getDataPath` to return `folderPath` directly after logging

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406cf34e9883318f115dd29908c211