### PR TITLE
Add recursive project initializer

### DIFF
--- a/.github/workflows/recursive-project-initializer.yml
+++ b/.github/workflows/recursive-project-initializer.yml
@@ -1,0 +1,39 @@
+name: Recursive project initializer
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/recursive-project-initializer.yml'
+      - 'docs/recursive-project-initializer.md'
+      - 'scripts/recursive-project-initializer.mjs'
+      - 'scripts/test-recursive-project-initializer.mjs'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/recursive-project-initializer.yml'
+      - 'scripts/recursive-project-initializer.mjs'
+      - 'scripts/test-recursive-project-initializer.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check script syntax
+        run: node --check scripts/recursive-project-initializer.mjs
+
+      - name: Run isolated recursive fixture
+        run: node scripts/test-recursive-project-initializer.mjs

--- a/docs/recursive-project-initializer.md
+++ b/docs/recursive-project-initializer.md
@@ -1,0 +1,94 @@
+# Recursive Project Initializer
+
+The repository contains Rush projects, nested `projects/` directories, standalone package roots, and Git submodules. `scripts/recursive-project-initializer.mjs` discovers all of them and applies the repository's first-initializer contract without replacing existing project documentation.
+
+## Completion contract
+
+For each discovered project root, the initializer ensures the following structure exists:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `.clinerules/README.md` unless a legacy `.clinerules` file already occupies that path
+- `.vscode/settings.json` with the required Copilot and chat-file settings
+- `README.md`
+- `memory-bank/chatmodes/README.md`
+- `memory-bank/instructions/README.md`
+- `memory-bank/prompts/README.md`
+- `memory-bank/activeContext.md`
+- `memory-bank/projectbrief.md`
+- `memory-bank/productContext.md`
+- `memory-bank/systemPatterns.md`
+- `memory-bank/techContext.md`
+- `memory-bank/progress.md`
+
+Existing files are preserved. Existing `.vscode/settings.json` data is retained and only missing required keys are added.
+
+## Discovery
+
+The initializer combines four sources:
+
+1. The repository root.
+2. Every active project in `rush.json`.
+3. Directories containing common project markers such as `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, Maven or Gradle manifests, and `rush-project.json`.
+4. Projects found recursively under any directory named `projects`, plus recursively initialized Git submodules declared by `.gitmodules`.
+
+Generated dependencies and caches such as `node_modules`, `.next`, `dist`, build outputs, virtual environments, and vendor directories are excluded.
+
+## Usage
+
+Initialize submodules first so their nested repositories can be inspected and updated:
+
+```bash
+git submodule update --init --recursive
+```
+
+Preview gaps without modifying files:
+
+```bash
+node scripts/recursive-project-initializer.mjs --check
+```
+
+Create missing scaffolding and repeat discovery until no further files are added:
+
+```bash
+node scripts/recursive-project-initializer.mjs --write
+```
+
+The write operation performs up to eight passes by default and then runs a final independent verification pass. It exits with code `2` if any project remains incomplete or inaccessible.
+
+Change the fixed-point limit when required:
+
+```bash
+node scripts/recursive-project-initializer.mjs --write --max-passes=20
+```
+
+Exclude Git submodules for a parent-repository-only operation:
+
+```bash
+node scripts/recursive-project-initializer.mjs --write --no-submodules
+```
+
+Run against a detached test fixture or alternate checkout:
+
+```bash
+node scripts/recursive-project-initializer.mjs --write --root=/path/to/repository
+```
+
+## Outputs
+
+`PROJECTS.generated.md` is regenerated in write mode. It records every discovered project, its discovery source, package name when supplied by Rush, and its completion status.
+
+Changes created inside a submodule belong to that submodule repository. Commit and publish those submodule changes first, then update the parent repository's gitlink commits.
+
+## Verification sequence
+
+Use the following sequence after generation:
+
+```bash
+node scripts/recursive-project-initializer.mjs --write
+node scripts/recursive-project-initializer.mjs --check
+git status --short
+git submodule foreach --recursive 'git status --short'
+```
+
+A complete result has `incomplete projects: 0` and a successful check exit code.

--- a/scripts/recursive-project-initializer.mjs
+++ b/scripts/recursive-project-initializer.mjs
@@ -1,0 +1,513 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import {
+  access,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const REQUIRED_VSCODE_SETTINGS = {
+  'github.copilot.chat.codeGeneration.useInstructionFiles': true,
+  'chat.modeFilesLocations': { 'memory-bank/chatmodes': true },
+  'chat.instructionsFilesLocations': { 'memory-bank/instructions': true },
+  'chat.promptFilesLocations': { 'memory-bank/prompts': true },
+  'github.copilot.chat.agent.thinkingTool': true,
+  'chat.todoListTool.enabled': true,
+  'chat.extensionTools.enabled': true,
+};
+
+const PROJECT_MARKERS = new Set([
+  'package.json',
+  'pyproject.toml',
+  'Cargo.toml',
+  'go.mod',
+  'rush-project.json',
+  'pom.xml',
+  'build.gradle',
+  'build.gradle.kts',
+]);
+
+const SKIP_DIRS = new Set([
+  '.cache',
+  '.git',
+  '.next',
+  '.pnpm-store',
+  '.rush',
+  '.turbo',
+  '.venv',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'temp',
+  'tmp',
+  'vendor',
+  'venv',
+]);
+
+const argv = new Set(process.argv.slice(2));
+const writeMode = argv.has('--write');
+const checkMode = argv.has('--check') || !writeMode;
+const includeSubmodules = !argv.has('--no-submodules');
+const maxPasses = Number(
+  process.argv.find((arg) => arg.startsWith('--max-passes='))?.split('=')[1] ?? 8,
+);
+const explicitRoot = process.argv
+  .find((arg) => arg.startsWith('--root='))
+  ?.slice('--root='.length);
+const repoRoot = path.resolve(explicitRoot ?? findRepoRoot());
+
+if (!Number.isInteger(maxPasses) || maxPasses < 1 || maxPasses > 100) {
+  throw new Error('--max-passes must be an integer from 1 to 100');
+}
+
+function findRepoRoot() {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function relativeProjectPath(projectRoot) {
+  const relative = path.relative(repoRoot, projectRoot);
+  return relative === '' ? '.' : relative.split(path.sep).join('/');
+}
+
+function stripJsonComments(input) {
+  let output = '';
+  let inString = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    const next = input[index + 1];
+
+    if (lineComment) {
+      if (char === '\n') {
+        lineComment = false;
+        output += char;
+      }
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false;
+        index += 1;
+      } else if (char === '\n') {
+        output += '\n';
+      }
+      continue;
+    }
+
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+    } else if (char === '/' && next === '/') {
+      lineComment = true;
+      index += 1;
+    } else if (char === '/' && next === '*') {
+      blockComment = true;
+      index += 1;
+    } else {
+      output += char;
+    }
+  }
+
+  return output.replace(/,\s*([}\]])/g, '$1');
+}
+
+async function readJsonc(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(stripJsonComments(raw));
+}
+
+async function isDirectory(candidate) {
+  try {
+    return (await stat(candidate)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function isFile(candidate) {
+  try {
+    return (await stat(candidate)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function hasProjectMarker(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return entries.some((entry) => entry.isFile() && PROJECT_MARKERS.has(entry.name));
+}
+
+async function discoverRushProjects(projects) {
+  const rushPath = path.join(repoRoot, 'rush.json');
+  if (!(await isFile(rushPath))) return;
+
+  const rush = await readJsonc(rushPath);
+  for (const project of rush.projects ?? []) {
+    if (typeof project?.projectFolder !== 'string') continue;
+    const projectRoot = path.resolve(repoRoot, project.projectFolder);
+    if (await isDirectory(projectRoot)) {
+      projects.set(projectRoot, {
+        source: 'rush.json',
+        packageName: project.packageName ?? null,
+      });
+    }
+  }
+}
+
+function parseGitmodules(raw, baseDirectory) {
+  const paths = [];
+  for (const line of raw.split(/\r?\n/u)) {
+    const match = line.match(/^\s*path\s*=\s*(.+?)\s*$/u);
+    if (match) paths.push(path.resolve(baseDirectory, match[1]));
+  }
+  return paths;
+}
+
+async function discoverSubmodules(projects) {
+  if (!includeSubmodules) return;
+
+  const queue = [repoRoot];
+  const visited = new Set();
+
+  while (queue.length > 0) {
+    const directory = queue.shift();
+    if (visited.has(directory)) continue;
+    visited.add(directory);
+
+    const gitmodulesPath = path.join(directory, '.gitmodules');
+    if (!(await isFile(gitmodulesPath))) continue;
+
+    const raw = await readFile(gitmodulesPath, 'utf8');
+    for (const submoduleRoot of parseGitmodules(raw, directory)) {
+      projects.set(submoduleRoot, {
+        source: '.gitmodules',
+        packageName: null,
+      });
+      if (await isDirectory(submoduleRoot)) queue.push(submoduleRoot);
+    }
+  }
+}
+
+async function discoverNestedProjects(projects) {
+  const visited = new Set();
+
+  async function walk(directory, insideProjectsDirectory = false) {
+    const realKey = path.resolve(directory);
+    if (visited.has(realKey)) return;
+    visited.add(realKey);
+
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const basename = path.basename(directory);
+    const nowInsideProjects = insideProjectsDirectory || basename === 'projects';
+
+    if (directory !== repoRoot && (await hasProjectMarker(directory))) {
+      projects.set(directory, {
+        source: nowInsideProjects ? 'projects-directory' : 'project-marker',
+        packageName: projects.get(directory)?.packageName ?? null,
+      });
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
+      await walk(path.join(directory, entry.name), nowInsideProjects);
+    }
+  }
+
+  await walk(repoRoot);
+}
+
+function projectTitle(projectRoot, metadata) {
+  if (metadata.packageName) return metadata.packageName;
+  if (projectRoot === repoRoot) return path.basename(repoRoot);
+  return path.basename(projectRoot);
+}
+
+function scaffoldFiles(projectRoot, metadata) {
+  const title = projectTitle(projectRoot, metadata);
+  const relative = relativeProjectPath(projectRoot);
+  const generatedNotice = '<!-- Generated by scripts/recursive-project-initializer.mjs. Existing files are preserved. -->';
+
+  return new Map([
+    [
+      'AGENTS.md',
+      `${generatedNotice}\n# Agent Guidelines — ${title}\n\n- Scope: \`${relative}\`.\n- Read the nearest parent \`AGENTS.md\` before editing.\n- Preserve public APIs and project conventions unless the task explicitly requires change.\n- Run the narrowest relevant checks before broader repository checks.\n- Never commit generated output, secrets, caches, or dependency directories.\n`,
+    ],
+    [
+      '.github/copilot-instructions.md',
+      `${generatedNotice}\n# Copilot Instructions — ${title}\n\nWork within \`${relative}\` and obey the nearest \`AGENTS.md\`. Inspect local manifests, tests, and README files before changing code. Prefer small, reviewable patches and report validation commands and unresolved risks.\n`,
+    ],
+    [
+      '.clinerules/README.md',
+      `${generatedNotice}\n# Cline Rules — ${title}\n\nUse the nearest \`AGENTS.md\` and \`.github/copilot-instructions.md\` as the authoritative project instructions. Preserve existing files and require explicit justification for destructive operations.\n`,
+    ],
+    [
+      'README.md',
+      `${generatedNotice}\n# ${title}\n\nProject root: \`${relative}\`.\n\n## Development\n\nInspect the local manifest and repository-level Rush configuration before installing, building, testing, or publishing this project.\n`,
+    ],
+    [
+      'memory-bank/chatmodes/README.md',
+      `${generatedNotice}\n# Chat Modes\n\nProject-specific VS Code chat modes for ${title}.\n`,
+    ],
+    [
+      'memory-bank/instructions/README.md',
+      `${generatedNotice}\n# Instructions\n\nReusable project instructions for ${title}.\n`,
+    ],
+    [
+      'memory-bank/prompts/README.md',
+      `${generatedNotice}\n# Prompts\n\nReusable project prompts for ${title}.\n`,
+    ],
+    [
+      'memory-bank/activeContext.md',
+      `${generatedNotice}\n# Active Context\n\nRecord the current objective, recent decisions, and immediate next actions for ${title}.\n`,
+    ],
+    [
+      'memory-bank/projectbrief.md',
+      `${generatedNotice}\n# Project Brief\n\nDescribe the purpose, scope, stakeholders, and constraints of ${title}.\n`,
+    ],
+    [
+      'memory-bank/productContext.md',
+      `${generatedNotice}\n# Product Context\n\nDescribe users, use cases, expected outcomes, and non-goals for ${title}.\n`,
+    ],
+    [
+      'memory-bank/systemPatterns.md',
+      `${generatedNotice}\n# System Patterns\n\nDocument architecture, boundaries, data flow, and recurring implementation patterns for ${title}.\n`,
+    ],
+    [
+      'memory-bank/techContext.md',
+      `${generatedNotice}\n# Technical Context\n\nDocument runtimes, frameworks, dependencies, commands, and environment assumptions for ${title}.\n`,
+    ],
+    [
+      'memory-bank/progress.md',
+      `${generatedNotice}\n# Progress\n\nTrack completed work, open work, blockers, and validation status for ${title}.\n`,
+    ],
+  ]);
+}
+
+async function ensureTextFile(filePath, content) {
+  if (existsSync(filePath)) return false;
+  if (!writeMode) return false;
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, { encoding: 'utf8', flag: 'wx' });
+  return true;
+}
+
+async function ensureVscodeSettings(projectRoot) {
+  const settingsPath = path.join(projectRoot, '.vscode/settings.json');
+  let settings = {};
+  let exists = false;
+
+  try {
+    settings = await readJsonc(settingsPath);
+    exists = true;
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      return {
+        changed: false,
+        problem: `cannot parse ${relativeProjectPath(settingsPath)}: ${error.message}`,
+      };
+    }
+  }
+
+  const merged = { ...settings };
+  let changed = !exists;
+  for (const [key, value] of Object.entries(REQUIRED_VSCODE_SETTINGS)) {
+    if (!(key in merged)) {
+      merged[key] = value;
+      changed = true;
+    }
+  }
+
+  if (changed && writeMode) {
+    await mkdir(path.dirname(settingsPath), { recursive: true });
+    await writeFile(settingsPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf8');
+  }
+
+  return { changed, problem: null };
+}
+
+async function inspectProject(projectRoot, metadata) {
+  const missing = [];
+  const problems = [];
+  let changed = 0;
+
+  if (!(await isDirectory(projectRoot))) {
+    return {
+      missing: [],
+      problems: [`unavailable project root: ${relativeProjectPath(projectRoot)}`],
+      changed: 0,
+    };
+  }
+
+  await access(projectRoot);
+  const scaffold = scaffoldFiles(projectRoot, metadata);
+
+  for (const [relativeFile, content] of scaffold) {
+    const filePath = path.join(projectRoot, relativeFile);
+
+    // A legacy .clinerules file and a .clinerules directory cannot coexist.
+    if (
+      relativeFile === '.clinerules/README.md' &&
+      (await isFile(path.join(projectRoot, '.clinerules')))
+    ) {
+      continue;
+    }
+
+    if (!existsSync(filePath)) {
+      missing.push(relativeFile);
+      if (await ensureTextFile(filePath, content)) changed += 1;
+    }
+  }
+
+  const settings = await ensureVscodeSettings(projectRoot);
+  if (settings.problem) problems.push(settings.problem);
+  if (settings.changed) {
+    missing.push('.vscode/settings.json (missing required keys)');
+    if (writeMode) changed += 1;
+  }
+
+  return { missing, problems, changed };
+}
+
+async function discoverProjects() {
+  const projects = new Map([
+    [repoRoot, { source: 'repository-root', packageName: null }],
+  ]);
+  await discoverRushProjects(projects);
+  await discoverSubmodules(projects);
+  await discoverNestedProjects(projects);
+  return new Map([...projects.entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+async function writeCatalog(projects, reports) {
+  const catalogPath = path.join(repoRoot, 'PROJECTS.generated.md');
+  const lines = [
+    '<!-- Generated by scripts/recursive-project-initializer.mjs. -->',
+    '# Project Catalog',
+    '',
+    `Generated from Rush configuration, project markers, nested \`projects/\` directories, and${includeSubmodules ? '' : ' excluding'} Git submodules.`,
+    '',
+    '| Project | Source | Package | Status |',
+    '|---|---|---|---|',
+  ];
+
+  for (const [projectRoot, metadata] of projects) {
+    const report = reports.get(projectRoot);
+    const status = report?.problems.length
+      ? `blocked: ${report.problems.join('; ')}`
+      : report?.missing.length
+        ? `missing ${report.missing.length}`
+        : 'complete';
+    lines.push(
+      `| \`${relativeProjectPath(projectRoot)}\` | ${metadata.source} | ${metadata.packageName ?? '—'} | ${status} |`,
+    );
+  }
+
+  const content = `${lines.join('\n')}\n`;
+  let previous = null;
+  try {
+    previous = await readFile(catalogPath, 'utf8');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+
+  if (previous !== content && writeMode) {
+    await writeFile(catalogPath, content, 'utf8');
+    return true;
+  }
+  return false;
+}
+
+async function main() {
+  let pass = 0;
+  let totalChanges = 0;
+  let projects = new Map();
+  let reports = new Map();
+
+  while (pass < maxPasses) {
+    pass += 1;
+    projects = await discoverProjects();
+    reports = new Map();
+    let passChanges = 0;
+
+    for (const [projectRoot, metadata] of projects) {
+      const report = await inspectProject(projectRoot, metadata);
+      reports.set(projectRoot, report);
+      passChanges += report.changed;
+    }
+
+    if (await writeCatalog(projects, reports)) passChanges += 1;
+    totalChanges += passChanges;
+
+    if (!writeMode || passChanges === 0) break;
+  }
+
+  // Final look-back verification pass.
+  projects = await discoverProjects();
+  reports = new Map();
+  let incomplete = 0;
+
+  for (const [projectRoot, metadata] of projects) {
+    const report = await inspectProject(projectRoot, metadata);
+    reports.set(projectRoot, report);
+    if (report.missing.length > 0 || report.problems.length > 0) incomplete += 1;
+  }
+
+  await writeCatalog(projects, reports);
+
+  console.log(`mode: ${writeMode ? 'write' : 'check'}`);
+  console.log(`root: ${repoRoot}`);
+  console.log(`projects: ${projects.size}`);
+  console.log(`passes: ${pass}`);
+  console.log(`files changed: ${totalChanges}`);
+  console.log(`incomplete projects: ${incomplete}`);
+
+  for (const [projectRoot, report] of reports) {
+    if (report.missing.length === 0 && report.problems.length === 0) continue;
+    console.log(`\n[${relativeProjectPath(projectRoot)}]`);
+    for (const item of report.missing) console.log(`  missing: ${item}`);
+    for (const item of report.problems) console.log(`  blocked: ${item}`);
+  }
+
+  if (checkMode && incomplete > 0) process.exitCode = 1;
+  if (writeMode && incomplete > 0) process.exitCode = 2;
+}
+
+await main();

--- a/scripts/test-recursive-project-initializer.mjs
+++ b/scripts/test-recursive-project-initializer.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const initializer = path.join(scriptDirectory, 'recursive-project-initializer.mjs');
+const fixture = await mkdtemp(path.join(os.tmpdir(), 'recursive-project-initializer-'));
+
+function run(...args) {
+  return spawnSync(process.execPath, [initializer, ...args], {
+    encoding: 'utf8',
+    cwd: fixture,
+  });
+}
+
+try {
+  const appRoot = path.join(fixture, 'frontend/projects/app');
+  const nestedRoot = path.join(fixture, 'frontend/projects/group/nested-app');
+  const submoduleRoot = path.join(fixture, 'services/example-submodule');
+
+  await mkdir(appRoot, { recursive: true });
+  await mkdir(nestedRoot, { recursive: true });
+  await mkdir(submoduleRoot, { recursive: true });
+
+  await writeFile(
+    path.join(fixture, 'rush.json'),
+    `{
+      // JSONC comments and trailing commas are intentional.
+      "projects": [
+        {
+          "packageName": "fixture-app",
+          "projectFolder": "frontend/projects/app",
+        },
+      ],
+    }
+`,
+    'utf8',
+  );
+  await writeFile(path.join(appRoot, 'package.json'), '{"name":"fixture-app"}\n', 'utf8');
+  await writeFile(path.join(nestedRoot, 'pyproject.toml'), '[project]\nname = "nested-app"\n', 'utf8');
+  await writeFile(path.join(submoduleRoot, 'go.mod'), 'module example.invalid/submodule\n', 'utf8');
+  await writeFile(
+    path.join(fixture, '.gitmodules'),
+    `[submodule "example-submodule"]
+      path = services/example-submodule
+      url = https://example.invalid/example-submodule.git
+`,
+    'utf8',
+  );
+
+  // Confirm a legacy .clinerules file is preserved instead of being replaced by a directory.
+  await writeFile(path.join(appRoot, '.clinerules'), 'preserve me\n', 'utf8');
+
+  const writeResult = run('--write', `--root=${fixture}`, '--max-passes=6');
+  assert.equal(
+    writeResult.status,
+    0,
+    `write failed\nstdout:\n${writeResult.stdout}\nstderr:\n${writeResult.stderr}`,
+  );
+  assert.match(writeResult.stdout, /incomplete projects: 0/u);
+
+  const checkResult = run('--check', `--root=${fixture}`);
+  assert.equal(
+    checkResult.status,
+    0,
+    `check failed\nstdout:\n${checkResult.stdout}\nstderr:\n${checkResult.stderr}`,
+  );
+  assert.match(checkResult.stdout, /files changed: 0/u);
+  assert.match(checkResult.stdout, /incomplete projects: 0/u);
+
+  for (const projectRoot of [fixture, appRoot, nestedRoot, submoduleRoot]) {
+    assert.ok(existsSync(path.join(projectRoot, 'AGENTS.md')));
+    assert.ok(existsSync(path.join(projectRoot, '.github/copilot-instructions.md')));
+    assert.ok(existsSync(path.join(projectRoot, '.vscode/settings.json')));
+    assert.ok(existsSync(path.join(projectRoot, 'memory-bank/progress.md')));
+  }
+
+  assert.equal(await readFile(path.join(appRoot, '.clinerules'), 'utf8'), 'preserve me\n');
+  assert.equal(existsSync(path.join(appRoot, '.clinerules/README.md')), false);
+
+  const catalog = await readFile(path.join(fixture, 'PROJECTS.generated.md'), 'utf8');
+  assert.match(catalog, /frontend\/projects\/app/u);
+  assert.match(catalog, /frontend\/projects\/group\/nested-app/u);
+  assert.match(catalog, /services\/example-submodule/u);
+  assert.doesNotMatch(catalog, /missing [1-9]/u);
+
+  console.log('recursive project initializer smoke test passed');
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

- adds an idempotent recursive project initializer
- discovers the repository root, Rush projects, nested `projects/` trees, marker-based projects, and Git submodule paths
- creates only missing agent instructions, Copilot instructions, VS Code settings, README files, and memory-bank scaffolding
- repeats write passes until a fixed point, then performs a final look-back verification
- generates `PROJECTS.generated.md` as a catalog when run in write mode
- adds an isolated fixture test and GitHub Actions workflow
- documents operation and safety constraints

## Safety

Existing files are preserved. Existing VS Code settings are merged by adding missing required keys only. Missing or uninitialized submodules are reported rather than modified.

## Validation

- `node --check scripts/recursive-project-initializer.mjs`
- local fixed-point smoke test: initial `--write` completed, subsequent `--check` reported zero incomplete projects

## Usage

```bash
git submodule update --init --recursive
node scripts/recursive-project-initializer.mjs --write
node scripts/recursive-project-initializer.mjs --check
```
